### PR TITLE
Add JUnit tests for WeightRecord

### DIFF
--- a/src/test/java/seedu/fitchasers/WeightRecordTest.java
+++ b/src/test/java/seedu/fitchasers/WeightRecordTest.java
@@ -1,0 +1,70 @@
+package seedu.fitchasers;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for the {@link WeightRecord} class.
+ * These tests verify that weight and date values are stored and formatted correctly.
+ */
+public class WeightRecordTest {
+
+    /**
+     * Tests that the constructor correctly initializes the weight and date fields.
+     */
+    @Test
+    public void testConstructorAndGetters() {
+        double expectedWeight = 70.5;
+        LocalDate expectedDate = LocalDate.of(2025, 10, 14);
+
+        WeightRecord record = new WeightRecord(expectedWeight, expectedDate);
+
+        assertEquals(expectedWeight, record.getWeight(),
+                "Weight should match the value provided in the constructor.");
+        assertEquals(expectedDate, record.getDate(),
+                "Date should match the value provided in the constructor.");
+    }
+
+    /**
+     * Tests that the toString() method returns the expected formatted string.
+     * Accepts both '.' and ',' as decimal separators depending on system locale.
+     */
+    @Test
+    public void testToStringFormatting() {
+        LocalDate date = LocalDate.of(2025, 10, 14);
+        WeightRecord record = new WeightRecord(70.5, date);
+
+        String expected = "Date: " + date.format(DateTimeFormatter.ofPattern("dd/MM/yy"))
+                + " | Weight: 70.5 kg";
+
+        // Replace ',' with '.' to avoid locale formatting issues
+        String actual = record.toString().replace(',', '.');
+
+        assertEquals(expected, actual,
+                "toString() should return a properly formatted record string.");
+    }
+
+    /**
+     * Tests that toString() includes both date and weight information.
+     */
+    @Test
+    public void testToStringContainsDateAndWeight() {
+        LocalDate date = LocalDate.of(2025, 1, 1);
+        WeightRecord record = new WeightRecord(60.0, date);
+        String output = record.toString();
+
+        String formattedDate = date.format(DateTimeFormatter.ofPattern("dd/MM/yy"));
+
+        // Normalize any locale differences
+        output = output.replace(',', '.');
+
+        assertEquals(true, output.contains(formattedDate),
+                "toString() should include the formatted date.");
+        assertEquals(true, output.contains("60.0"),
+                "toString() should include the weight value.");
+    }
+}


### PR DESCRIPTION
Fixes #70 

The tests cover the following aspects:
- Constructor initializes weight and date correctly
- Getter methods return expected values
- toString() formatting matches the required format ("Date: dd/MM/yy | Weight: XX.X kg")