### PR TITLE
Fix create_workout extraction for partial datetime

### DIFF
--- a/src/main/java/seedu/fitchasers/WorkoutManager.java
+++ b/src/main/java/seedu/fitchasers/WorkoutManager.java
@@ -43,10 +43,16 @@ public class WorkoutManager {
             workoutName = command.substring(nIndex + 2).trim();
         }
 
-        String dateStr = extractBetween(command, "d/", "t/").trim();
+        String dateStr = "";
+        if (command.contains("d/")) {
+            String[] dateTokens = extractAfter(command, "d/").split("\\s+");
+            dateStr = dateTokens[0].trim();
+        }
+
         String timeStr = "";
         if (command.contains("t/")) {
-            timeStr = command.substring(command.indexOf("t/") + 2).trim();
+            String[] timeTokens = extractAfter(command, "t/").split("\\s+");
+            timeStr = timeTokens[0].trim();
         }
 
         if(dateStr.isEmpty()) {


### PR DESCRIPTION
Improve parsing of date and time arguments in create_workout.
If only date or time is entered, default only the missing part to
the system value. This prevents unintended use of both fields when
user input is partial.

Closes #105